### PR TITLE
adapt to dotnet.core 3.1 build

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -31,4 +31,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
           name: Rail (${{ matrix.build_platform }})
-          path: Rail.Installer\Installs\Rail-0.1.0.0-Release-${{ matrix.build_platform }}.msi"
+          path: Rail.Installer\Installs\Rail-0.1.0.0-Release-${{ matrix.build_platform }}.msi

--- a/Rail/Rail.csproj
+++ b/Rail/Rail.csproj
@@ -81,7 +81,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RailTest/RailTest.csproj
+++ b/RailTest/RailTest.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,10 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 
 platform:
+    - x64
+    - x86
     - Any CPU
 
 configuration:
@@ -10,23 +12,28 @@ configuration:
     - Debug
 
 install:
-    - if "%platform%"=="Any CPU" set archi=x86
-    - if "%platform%"=="Any CPU" set platform_input=Any CPU
+    - ps: >-
+        Start-FileDownload 'https://wixtoolset.gallerycdn.vsassets.io/extensions/wixtoolset/wixtoolsetvisualstudio2019extension/1.0.0.4/1563296438961/Votive2019.vsix'
 
-    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\Rail\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
+        Write-Host "Installing VSIX..."
+
+        . "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\VSIXInstaller.exe" /q /a Votive2019.vsix
+        Write-Host "InstallerProjects installed" -ForegroundColor Green
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
-    - msbuild Rail.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform_input%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild Rail.sln /m /verbosity:minimal /t:restore /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild Rail.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
-    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - cd "%APPVEYOR_BUILD_FOLDER%"\Rail.Installer\Installs
+    - dir
     - ps: >-
-        Push-AppveyorArtifact "Rail\bin\$env:CONFIGURATION\Rail.exe" -FileName Rail.exe
+        Push-AppveyorArtifact "Rail-*.msi" -FileName Rail-*.msi
 
         if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release") {
             $ZipFileName = "Rail_$($env:APPVEYOR_REPO_TAG_NAME).zip"
-            7z a $ZipFileName "%APPVEYOR_BUILD_FOLDER%\Rail\bin\$env:CONFIGURATION\Rail.exe"
+            7z a $ZipFileName "%APPVEYOR_BUILD_FOLDER%\Rail\bin\$env:CONFIGURATION\netcoreapp3.1\Rail.dll"
         }
 
 artifacts:


### PR DESCRIPTION
- update nuget packages

- see https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners#windows-server-2019 for installed SW, wix and extension is already preinstalled
- see https://ci.appveyor.com/project/chcg/rail/build/job/c6alxer0ajrski8g

> 
>  Rail -> C:\projects\rail\Rail\bin\x64\Release\netcoreapp3.1\win-x64\Rail.dll
>     Rail -> C:\projects\rail\Rail\bin\x64\Release\netcoreapp3.1\win-x64\publish\
> C:\projects\rail\Rail.Installer\Rail.Installer.wixproj(72,5): error MSB3441: Cannot get assembly name for "..\Rail\bin\Release\netcoreapp3.1\win-x64\Rail.dll". Could not load file or assembly 'Rail.dll' or one of its dependencies. The system cannot find the path specified.
>   RailTest -> C:\projects\rail\RailTest\bin\Release\netcoreapp3.1\RailTest.dll
> Command exited with code 1

appveyor has an extra folder with platform which is not there on github